### PR TITLE
ci: remove build for macos

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,6 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - macos-latest
     runs-on: ${{ matrix.os }}
     steps:
       - name: asdf_plugin_test


### PR DESCRIPTION
Current version of plugin will be support only for linux-amd64